### PR TITLE
Add language parameter to getHotelDetails

### DIFF
--- a/index.js
+++ b/index.js
@@ -435,9 +435,10 @@ class LiteApi {
     /**
     * The hotel details API returns all the static contents details of a hotel or property if the hotel ID is provided. The static content include name, description, address, amenities, cancellation policies, images and more.
     * @param {string} hotelId - Unique ID of a hotel
+    * @param {string} language - Language code for the response (optional)
     * @returns {array} - The result of the operation.
     */
-    async getHotelDetails(hotelId) {
+    async getHotelDetails(hotelId, language) {
         let errors = [];
         if (hotelId == "" || hotelId === undefined) {
             errors.push("The Hotel code is required");
@@ -451,7 +452,7 @@ class LiteApi {
                 'X-API-Key': this.apiKey
             },
         };
-        const response = await fetch(this.serviceURL + '/data/hotel?hotelId=' + hotelId, options)
+        const response = await fetch(this.serviceURL + '/data/hotel?hotelId=' + hotelId + (language ? '&language=' + encodeURIComponent(language) : ''), options)
         const data = await response.json();
         if (!response.ok) {
             return {

--- a/index.js
+++ b/index.js
@@ -405,9 +405,10 @@ class LiteApi {
     * The minimum required information is the country code in ISO-2 format. The API supports additional search criteria such as city name, geo coordinates, and radius.
     * This endpoint provides detailed hotel metadata, including names, addresses, ratings, amenities, and images, facilitating robust hotel search and display features within applications.
     * @param {string} parameters - The search criteria parameters.
+    * @param {string} language - Language code for the response (optional)
     * @returns {array} - The result of the operation.
     */
-    async getHotels(parameters) {
+    async getHotels(parameters, language) {
         const options = {
             method: 'GET',
             headers: {
@@ -418,7 +419,8 @@ class LiteApi {
         };
 
         const query = decodeURIComponent(new URLSearchParams(parameters || {}).toString());
-        const response = await fetch(this.serviceURL + '/data/hotels?' + query, options)
+        const languageQuery = language ? '&language=' + encodeURIComponent(language) : '';
+        const response = await fetch(this.serviceURL + '/data/hotels?' + query + languageQuery, options)
         const data = await response.json();
 
         if (!response.ok) {

--- a/test/test.js
+++ b/test/test.js
@@ -129,14 +129,14 @@ describe('LiteAPI SDK Test Suite', function() {
   });
 
   it('should retrieve hotels by country and city', async function() {
-    const result = await liteApi.getHotels({ countryCode: 'IT', cityName: 'Rome' });
+    const result = await liteApi.getHotels({ countryCode: 'IT', cityName: 'Rome', language: 'fr' });
     expect(result).to.have.property('status', 'success');
     expect(result).to.have.property('data');
     expect(result.data).to.be.an('array');
   });
 
   it('should retrieve hotel details by ID', async function() {
-    const result = await liteApi.getHotelDetails('lp1897');
+    const result = await liteApi.getHotelDetails('lp1897', 'fr');
     expect(result).to.have.property('status', 'success');
     expect(result).to.have.property('data');
     expect(result.data).to.be.an('object');


### PR DESCRIPTION
The getHotelDetails method now accepts an additional optional parameter, language, which specifies the desired language for the response

### Screenshots
get hotel details with the french language param:
![Screenshot 2025-01-31 at 15 29 43](https://github.com/user-attachments/assets/fb5def13-9eba-4dff-be60-a9fe7dbe8a1f)
get list of hotels with the french language param:
![Screenshot 2025-01-31 at 15 31 16](https://github.com/user-attachments/assets/1a2a5eab-dc9a-4a60-b1de-414aca68b8e8)
